### PR TITLE
feat: Add PDF thumbnail generation feature

### DIFF
--- a/app/Console/Commands/RegenerateThumbnails.php
+++ b/app/Console/Commands/RegenerateThumbnails.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Document;
+use App\Collection;
+use App\Services\ThumbnailService;
+use Illuminate\Support\Facades\Log;
+
+class RegenerateThumbnails extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'SR:RegenerateThumbnails {collection_id : ID of the collection or "all" for all collections}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Regenerates PDF thumbnails for documents in a collection';
+
+    /**
+     * Thumbnail service instance
+     *
+     * @var ThumbnailService
+     */
+    protected $thumbnailService;
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->thumbnailService = new ThumbnailService();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $collection_id = $this->argument('collection_id');
+        
+        if ($collection_id == 'all') {
+            $collections = Collection::where('content_type', 'Uploaded documents')->get();
+            
+            $this->info('Regenerating thumbnails for all collections...');
+            
+            foreach ($collections as $collection) {
+                $this->regenerateCollectionThumbnails($collection);
+            }
+            
+            $this->info('Completed thumbnail regeneration for all collections.');
+        } else {
+            $collection = Collection::find($collection_id);
+            
+            if (!$collection) {
+                $this->error("Collection with ID {$collection_id} not found.");
+                return 1;
+            }
+            
+            if ($collection->content_type !== 'Uploaded documents') {
+                $this->error("Collection must be of type 'Uploaded documents'.");
+                return 1;
+            }
+            
+            $this->regenerateCollectionThumbnails($collection);
+        }
+        
+        return 0;
+    }
+
+    /**
+     * Regenerate thumbnails for a specific collection
+     *
+     * @param Collection $collection
+     * @return void
+     */
+    protected function regenerateCollectionThumbnails($collection)
+    {
+        $this->info("Processing collection: {$collection->name} (ID: {$collection->id})");
+        
+        // Get all PDF documents in the collection
+        $documents = Document::where('collection_id', $collection->id)
+            ->where(function($query) {
+                $query->where('type', 'application/pdf')
+                      ->orWhere('type', 'like', '%application/pdf%');
+            })
+            ->get();
+        
+        if ($documents->isEmpty()) {
+            $this->info("No PDF documents found in this collection.");
+            return;
+        }
+        
+        $this->info("Found {$documents->count()} PDF document(s). Generating thumbnails...");
+        
+        $bar = $this->output->createProgressBar($documents->count());
+        $bar->start();
+        
+        $success = 0;
+        $failed = 0;
+        
+        foreach ($documents as $document) {
+            try {
+                $result = $this->thumbnailService->regenerateThumbnail($document);
+                
+                if ($result) {
+                    $success++;
+                } else {
+                    $failed++;
+                    Log::warning("Failed to generate thumbnail for document ID: {$document->id}");
+                }
+            } catch (\Exception $e) {
+                $failed++;
+                Log::error("Error generating thumbnail for document ID {$document->id}: " . $e->getMessage());
+            }
+            
+            $bar->advance();
+        }
+        
+        $bar->finish();
+        $this->newLine();
+        
+        $this->info("Thumbnail generation completed for collection '{$collection->name}':");
+        $this->info("  - Success: {$success}");
+        $this->info("  - Failed: {$failed}");
+        $this->newLine();
+    }
+}

--- a/app/Document.php
+++ b/app/Document.php
@@ -210,7 +210,7 @@ class Document extends Model implements Auditable
             return null;
         }
 
-        $thumbnailPath = "doc-thumbnails/{$this->collection_id}/{$this->id}/thumbnail.jpg";
+        $thumbnailPath = "doc-thumbnails/{$this->collection_id}/{$this->id}_thumb.jpg";
         
         if (\Storage::disk('public')->exists($thumbnailPath)) {
             return asset("storage/{$thumbnailPath}");

--- a/app/Document.php
+++ b/app/Document.php
@@ -10,6 +10,7 @@ use OwenIt\Auditing\Contracts\Auditable;
 use Carbon\Carbon;
 use App\Taxonomy;
 use App\Approval;
+use Illuminate\Support\Facades\Storage;
 
 class Document extends Model implements Auditable
 {
@@ -194,6 +195,38 @@ class Document extends Model implements Auditable
             $approved_by_role = @$latest_approval_record->approver_role->name;
             return "Approval pending at ".ucfirst($approved_by_role);
         }
+    }
+
+    /**
+     * Get the thumbnail URL for a PDF document
+     * Returns the thumbnail URL if it exists, otherwise returns null
+     * 
+     * @return string|null
+     */
+    public function getThumbnailUrl()
+    {
+        // Only check for PDF documents
+        if ($this->type !== 'application/pdf' && !str_contains($this->type, 'application/pdf')) {
+            return null;
+        }
+
+        $thumbnailPath = "doc-thumbnails/{$this->collection_id}/{$this->id}/thumbnail.jpg";
+        
+        if (\Storage::disk('public')->exists($thumbnailPath)) {
+            return asset("storage/{$thumbnailPath}");
+        }
+        
+        return null;
+    }
+
+    /**
+     * Check if document has a thumbnail
+     * 
+     * @return bool
+     */
+    public function hasThumbnail()
+    {
+        return !is_null($this->getThumbnailUrl());
     }
 
 }

--- a/app/Listeners/DocumentSaved.php
+++ b/app/Listeners/DocumentSaved.php
@@ -95,22 +95,33 @@ class DocumentSaved
 	    		Log::warning($e->getMessage());
 	    	}
 
-        // Generate PDF thumbnail if document is a PDF
-        if ($event->document->type == 'application/pdf') {
+        // Generate PDF thumbnail only if a PDF file was uploaded
+        // Check if document was recently created/updated with a file
+        if ($event->document->type == 'application/pdf' && !empty($event->document->path)) {
             $thumbnailService = new ThumbnailService();
             
             // Get the PDF file path
             $collection = $event->document->collection;
             $storageDrive = empty($collection->storage_drive) ? 'local' : $collection->storage_drive;
             
-            if ($storageDrive === 'local' && !empty($event->document->path)) {
+            // Only generate thumbnail if file is on local storage and exists
+            if ($storageDrive === 'local') {
                 $pdfPath = storage_path('app/' . $event->document->path);
+                
+                // Check if file exists and was recently modified (uploaded/updated)
                 if (file_exists($pdfPath)) {
-                    try {
-                        $thumbnailService->generateThumbnail($pdfPath, $event->document->collection_id, $event->document->id);
-                        Log::info('PDF thumbnail generated for document ' . $event->document->id);
-                    } catch (\Exception $e) {
-                        Log::warning('Failed to generate thumbnail for document ' . $event->document->id . ': ' . $e->getMessage());
+                    $fileModifiedTime = filemtime($pdfPath);
+                    $documentUpdatedTime = strtotime($event->document->updated_at);
+                    
+                    // Generate thumbnail only if file was modified within last 5 minutes
+                    // This ensures we only regenerate when file is actually uploaded
+                    if (($documentUpdatedTime - $fileModifiedTime) < 300) {
+                        try {
+                            $thumbnailService->generateThumbnail($pdfPath, $event->document->collection_id, $event->document->id);
+                            Log::info('PDF thumbnail generated for document ' . $event->document->id);
+                        } catch (\Exception $e) {
+                            Log::warning('Failed to generate thumbnail for document ' . $event->document->id . ': ' . $e->getMessage());
+                        }
                     }
                 }
             }

--- a/app/Listeners/DocumentSaved.php
+++ b/app/Listeners/DocumentSaved.php
@@ -9,6 +9,7 @@ use Elastic\Elasticsearch\ClientBuilder;
 use Illuminate\Support\Facades\Notification;
 use App\Notifications\DocumentSaved as DocumentSavedNotification;
 use App\Approval;
+use App\Services\ThumbnailService;
 
 class DocumentSaved
 {
@@ -93,5 +94,26 @@ class DocumentSaved
 	    	catch(\Exception $e){
 	    		Log::warning($e->getMessage());
 	    	}
+
+        // Generate PDF thumbnail if document is a PDF
+        if ($event->document->type == 'application/pdf') {
+            $thumbnailService = new ThumbnailService();
+            
+            // Get the PDF file path
+            $collection = $event->document->collection;
+            $storageDrive = empty($collection->storage_drive) ? 'local' : $collection->storage_drive;
+            
+            if ($storageDrive === 'local' && !empty($event->document->path)) {
+                $pdfPath = storage_path('app/' . $event->document->path);
+                if (file_exists($pdfPath)) {
+                    try {
+                        $thumbnailService->generateThumbnail($pdfPath, $event->document->collection_id, $event->document->id);
+                        Log::info('PDF thumbnail generated for document ' . $event->document->id);
+                    } catch (\Exception $e) {
+                        Log::warning('Failed to generate thumbnail for document ' . $event->document->id . ': ' . $e->getMessage());
+                    }
+                }
+            }
+        }
     }
 }

--- a/app/Services/ThumbnailService.php
+++ b/app/Services/ThumbnailService.php
@@ -1,0 +1,297 @@
+<?php
+
+namespace App\Services;
+
+use Spatie\PdfToImage\Pdf;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Log;
+
+class ThumbnailService
+{
+    /**
+     * Generate a thumbnail for a PDF document
+     * 
+     * @param string $pdfPath Full path to the PDF file in storage
+     * @param int $collectionId Collection ID
+     * @param int $documentId Document ID
+     * @return bool Success status
+     */
+    public function generateThumbnail($pdfPath, $collectionId, $documentId)
+    {
+        try {
+            // Ensure the PDF file exists
+            if (!file_exists($pdfPath)) {
+                Log::error("PDF file not found: {$pdfPath}");
+                return false;
+            }
+
+            // Create thumbnail directory if it doesn't exist
+            $thumbnailDir = storage_path("app/public/doc-thumbnails/{$collectionId}/{$documentId}");
+            if (!is_dir($thumbnailDir)) {
+                mkdir($thumbnailDir, 0755, true);
+            }
+
+            $thumbnailPath = "{$thumbnailDir}/thumbnail.jpg";
+
+            // Try Imagick first, then fall back to Ghostscript + GD
+            if (extension_loaded('imagick')) {
+                return $this->generateWithImagick($pdfPath, $thumbnailPath, $documentId);
+            } else {
+                return $this->generateWithGhostscript($pdfPath, $thumbnailPath, $documentId);
+            }
+
+        } catch (\Exception $e) {
+            Log::error("Failed to generate thumbnail for document {$documentId}: " . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Generate thumbnail using Imagick
+     */
+    private function generateWithImagick($pdfPath, $thumbnailPath, $documentId)
+    {
+        try {
+            $pdf = new Pdf($pdfPath);
+            $pdf->setPage(1)
+                ->setOutputFormat('jpg')
+                ->setCompressionQuality(80);
+            
+            $pdf->saveImage($thumbnailPath);
+
+            Log::info("Thumbnail generated with Imagick for document {$documentId}");
+            return true;
+        } catch (\Exception $e) {
+            Log::error("Imagick thumbnail generation failed: " . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Generate thumbnail using Ghostscript
+     */
+    private function generateWithGhostscript($pdfPath, $thumbnailPath, $documentId)
+    {
+        try {
+            // Find Ghostscript executable
+            $gsPath = $this->findGhostscript();
+            
+            if (!$gsPath) {
+                Log::warning('Ghostscript not found. Thumbnail generation skipped for document ' . $documentId);
+                return false;
+            }
+
+            // Convert first page to PNG using Ghostscript
+            $tempPng = sys_get_temp_dir() . '/pdf_thumb_' . $documentId . '.png';
+            
+            $command = sprintf(
+                '"%s" -dSAFER -dBATCH -dNOPAUSE -dFirstPage=1 -dLastPage=1 -sDEVICE=png16m -r150 -sOutputFile="%s" "%s" 2>&1',
+                $gsPath,
+                $tempPng,
+                $pdfPath
+            );
+
+            exec($command, $output, $returnCode);
+
+            if ($returnCode !== 0 || !file_exists($tempPng)) {
+                Log::error("Ghostscript failed for document {$documentId}: " . implode("\n", $output));
+                return false;
+            }
+
+            // Resize using GD library
+            $this->resizeImageWithGD($tempPng, $thumbnailPath, 200, 200);
+
+            // Clean up temp file
+            if (file_exists($tempPng)) {
+                unlink($tempPng);
+            }
+
+            Log::info("Thumbnail generated with Ghostscript for document {$documentId}");
+            return true;
+
+        } catch (\Exception $e) {
+            Log::error("Ghostscript thumbnail generation failed: " . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Find Ghostscript executable path
+     */
+    private function findGhostscript()
+    {
+        // Common Ghostscript paths on Windows
+        $possiblePaths = [
+            'C:/Program Files/gs/gs*/bin/gswin64c.exe',
+            'C:/Program Files (x86)/gs/gs*/bin/gswin32c.exe',
+            'gswin64c', // If in PATH
+            'gswin32c',
+            'gs',
+        ];
+
+        foreach ($possiblePaths as $path) {
+            if (strpos($path, '*') !== false) {
+                // Handle wildcard paths
+                $matches = glob($path);
+                if (!empty($matches)) {
+                    return $matches[0];
+                }
+            } else {
+                // Check if executable exists or is in PATH
+                $check = shell_exec("where {$path} 2>nul");
+                if (!empty($check)) {
+                    return trim(explode("\n", $check)[0]);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Resize image using GD library
+     */
+    private function resizeImageWithGD($sourcePath, $destPath, $maxWidth, $maxHeight)
+    {
+        list($width, $height, $type) = getimagesize($sourcePath);
+
+        // Calculate new dimensions
+        $ratio = min($maxWidth / $width, $maxHeight / $height);
+        $newWidth = (int)($width * $ratio);
+        $newHeight = (int)($height * $ratio);
+
+        // Create image from source
+        switch ($type) {
+            case IMAGETYPE_PNG:
+                $source = imagecreatefrompng($sourcePath);
+                break;
+            case IMAGETYPE_JPEG:
+                $source = imagecreatefromjpeg($sourcePath);
+                break;
+            default:
+                throw new \Exception('Unsupported image type');
+        }
+
+        // Create new image
+        $thumb = imagecreatetruecolor($newWidth, $newHeight);
+        
+        // Preserve transparency for PNG
+        if ($type == IMAGETYPE_PNG) {
+            imagealphablending($thumb, false);
+            imagesavealpha($thumb, true);
+        }
+
+        // Resize
+        imagecopyresampled($thumb, $source, 0, 0, 0, 0, $newWidth, $newHeight, $width, $height);
+
+        // Save as JPEG
+        imagejpeg($thumb, $destPath, 80);
+
+        // Free memory
+        imagedestroy($source);
+        imagedestroy($thumb);
+    }
+
+    /**
+     * Get the URL for a document's thumbnail
+     * 
+     * @param int $collectionId Collection ID
+     * @param int $documentId Document ID
+     * @return string|null Thumbnail URL or null if not exists
+     */
+    public function getThumbnailUrl($collectionId, $documentId)
+    {
+        $thumbnailPath = "doc-thumbnails/{$collectionId}/{$documentId}/thumbnail.jpg";
+        
+        if (Storage::disk('public')->exists($thumbnailPath)) {
+            return asset("storage/{$thumbnailPath}");
+        }
+        
+        return null;
+    }
+
+    /**
+     * Check if a thumbnail exists for a document
+     * 
+     * @param int $collectionId Collection ID
+     * @param int $documentId Document ID
+     * @return bool
+     */
+    public function thumbnailExists($collectionId, $documentId)
+    {
+        $thumbnailPath = "doc-thumbnails/{$collectionId}/{$documentId}/thumbnail.jpg";
+        return Storage::disk('public')->exists($thumbnailPath);
+    }
+
+    /**
+     * Delete a document's thumbnail
+     * 
+     * @param int $collectionId Collection ID
+     * @param int $documentId Document ID
+     * @return bool
+     */
+    public function deleteThumbnail($collectionId, $documentId)
+    {
+        try {
+            $thumbnailPath = "doc-thumbnails/{$collectionId}/{$documentId}/thumbnail.jpg";
+            
+            if (Storage::disk('public')->exists($thumbnailPath)) {
+                Storage::disk('public')->delete($thumbnailPath);
+                
+                // Try to remove the directory if empty
+                $thumbnailDir = storage_path("app/public/doc-thumbnails/{$collectionId}/{$documentId}");
+                if (is_dir($thumbnailDir) && count(scandir($thumbnailDir)) === 2) {
+                    rmdir($thumbnailDir);
+                }
+            }
+            
+            return true;
+        } catch (\Exception $e) {
+            Log::error("Failed to delete thumbnail for document {$documentId}: " . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Regenerate thumbnail for a document
+     * 
+     * @param \App\Document $document
+     * @return bool
+     */
+    public function regenerateThumbnail($document)
+    {
+        // Get the PDF path from document
+        $collection = \App\Collection::find($document->collection_id);
+        $storageDrive = empty($collection->storage_drive) ? 'local' : $collection->storage_drive;
+        
+        // Only process PDF files
+        if ($document->type !== 'application/pdf') {
+            return false;
+        }
+
+        try {
+            // If stored remotely, we need to download it temporarily
+            if ($storageDrive !== 'local') {
+                $tempPath = storage_path('app/temp_' . $document->id . '.pdf');
+                $content = Storage::disk($storageDrive)->get($document->path);
+                file_put_contents($tempPath, $content);
+                $pdfPath = $tempPath;
+            } else {
+                $pdfPath = storage_path('app/' . $document->path);
+            }
+
+            $result = $this->generateThumbnail($pdfPath, $document->collection_id, $document->id);
+
+            // Clean up temp file if created
+            if ($storageDrive !== 'local' && isset($tempPath) && file_exists($tempPath)) {
+                unlink($tempPath);
+            }
+
+            return $result;
+
+        } catch (\Exception $e) {
+            Log::error("Failed to regenerate thumbnail for document {$document->id}: " . $e->getMessage());
+            return false;
+        }
+    }
+}

--- a/app/Services/ThumbnailService.php
+++ b/app/Services/ThumbnailService.php
@@ -25,13 +25,13 @@ class ThumbnailService
                 return false;
             }
 
-            // Create thumbnail directory if it doesn't exist
-            $thumbnailDir = storage_path("app/public/doc-thumbnails/{$collectionId}/{$documentId}");
+            // Create collection-level thumbnail directory if it doesn't exist
+            $thumbnailDir = storage_path("app/public/doc-thumbnails/{$collectionId}");
             if (!is_dir($thumbnailDir)) {
                 mkdir($thumbnailDir, 0755, true);
             }
 
-            $thumbnailPath = "{$thumbnailDir}/thumbnail.jpg";
+            $thumbnailPath = "{$thumbnailDir}/{$documentId}_thumb.jpg";
 
             // Try Imagick first, then fall back to Ghostscript + GD
             if (extension_loaded('imagick')) {
@@ -201,16 +201,14 @@ class ThumbnailService
      */
     public function getThumbnailUrl($collectionId, $documentId)
     {
-        $thumbnailPath = "doc-thumbnails/{$collectionId}/{$documentId}/thumbnail.jpg";
-        
+        $thumbnailPath = "doc-thumbnails/{$collectionId}/{$documentId}_thumb.jpg";
+
         if (Storage::disk('public')->exists($thumbnailPath)) {
             return asset("storage/{$thumbnailPath}");
         }
-        
-        return null;
-    }
 
-    /**
+        return null;
+    }    /**
      * Check if a thumbnail exists for a document
      * 
      * @param int $collectionId Collection ID
@@ -219,7 +217,7 @@ class ThumbnailService
      */
     public function thumbnailExists($collectionId, $documentId)
     {
-        $thumbnailPath = "doc-thumbnails/{$collectionId}/{$documentId}/thumbnail.jpg";
+        $thumbnailPath = "doc-thumbnails/{$collectionId}/{$documentId}_thumb.jpg";
         return Storage::disk('public')->exists($thumbnailPath);
     }
 
@@ -233,26 +231,18 @@ class ThumbnailService
     public function deleteThumbnail($collectionId, $documentId)
     {
         try {
-            $thumbnailPath = "doc-thumbnails/{$collectionId}/{$documentId}/thumbnail.jpg";
-            
+            $thumbnailPath = "doc-thumbnails/{$collectionId}/{$documentId}_thumb.jpg";
+
             if (Storage::disk('public')->exists($thumbnailPath)) {
                 Storage::disk('public')->delete($thumbnailPath);
-                
-                // Try to remove the directory if empty
-                $thumbnailDir = storage_path("app/public/doc-thumbnails/{$collectionId}/{$documentId}");
-                if (is_dir($thumbnailDir) && count(scandir($thumbnailDir)) === 2) {
-                    rmdir($thumbnailDir);
-                }
             }
-            
+
             return true;
         } catch (\Exception $e) {
             Log::error("Failed to delete thumbnail for document {$documentId}: " . $e->getMessage());
             return false;
         }
-    }
-
-    /**
+    }    /**
      * Regenerate thumbnail for a document
      * 
      * @param \App\Document $document

--- a/app/Traits/Search.php
+++ b/app/Traits/Search.php
@@ -826,8 +826,15 @@ trait Search{
             }
         }
 	    $title = '<h6>'.mb_convert_encoding($title, 'UTF-8', 'UTF-8').'</h6><p>'.strip_tags(implode(' ... ', $content_matches), '<em>').'</p>';
+        
+        // Check if document has a thumbnail
+        $thumbnailUrl = $d->getThumbnailUrl();
+        $iconDisplay = $thumbnailUrl 
+            ? '<img class="file-icon" src="'.$thumbnailUrl.'" style="width:50px; height:50px; object-fit:cover;" />' 
+            : '<img class="file-icon" src="/i/file-types/'.$d->icon().'.png" />';
+        
         $result = array(
-                'type' => array('display'=>'<img class="file-icon" src="/i/file-types/'.$d->icon().'.png" />', 'filetype'=>$d->icon()),
+                'type' => array('display'=>$iconDisplay, 'filetype'=>$d->icon()),
                 'title' => $title,
                 'approval_status' => $approval_status,
                 'size' => array('display'=>$d->human_filesize(), 'bytes'=>$d->size),

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "smalot/pdfparser": "^0.14.0",
         "spatie/crawler": "^4.7",
         "spatie/image-optimizer": "^1.2",
+        "spatie/pdf-to-image": "^3.1",
         "spatie/pdf-to-text": "^1.4",
         "swiftmailer/swiftmailer": "^6.0",
         "thiagoalessio/tesseract_ocr": "^2.13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "debe53eee76efef03bc1551682fdb232",
+    "content-hash": "8cd208872f8ba809905a079d1a1c0fd9",
     "packages": [
         {
             "name": "aacotroneo/laravel-saml2",
@@ -8495,6 +8495,76 @@
             "time": "2020-11-03T10:15:05+00:00"
         },
         {
+            "name": "spatie/pdf-to-image",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/pdf-to-image.git",
+                "reference": "acc31c5236180e475c09c1a5c68412876f0bd89a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/pdf-to-image/zipball/acc31c5236180e475c09c1a5c68412876f0bd89a",
+                "reference": "acc31c5236180e475c09c1a5c68412876f0bd89a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-imagick": "*",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "pestphp/pest": "^2.34"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\PdfToImage\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Patrick Organ",
+                    "email": "patrick@permafrost.dev",
+                    "homepage": "https://permafrost.dev",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Convert a pdf to an image",
+            "homepage": "https://github.com/spatie/pdf-to-image",
+            "keywords": [
+                "convert",
+                "image",
+                "pdf",
+                "pdf-to-image",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/pdf-to-image/issues",
+                "source": "https://github.com/spatie/pdf-to-image/tree/3.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-09-14T17:02:32+00:00"
+        },
+        {
             "name": "spatie/pdf-to-text",
             "version": "1.52.1",
             "source": {
@@ -13825,12 +13895,12 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -48,7 +48,6 @@ return [
             'root' => env('LOCAL_STORAGE_PATH', storage_path()).'/app',
         ],
 
-	/*
         'public' => [
             'driver' => 'local',
             'root' => storage_path('app/public'),
@@ -56,11 +55,11 @@ return [
             'visibility' => 'public',
         ],
 
+	/*
         'ketan_temp' => [
             'driver' => 'local',
             'root' => '/home/ketan/tmp',
         ],
-
 
         's3' => [
             'driver' => 's3',


### PR DESCRIPTION
## 📄 PDF Thumbnail Generation Feature

### Overview
This PR implements automatic PDF thumbnail generation for uploaded documents. Thumbnails are pre-generated during upload and displayed in the collection list view for faster loading and better visual representation.

### Changes Made

#### New Files
- **`app/Services/ThumbnailService.php`** - Core service for PDF thumbnail generation
  - Supports both Imagick and Ghostscript + GD library
  - Generates 200x200px JPEG thumbnails from first page
  - Stores at `storage/app/public/doc-thumbnails/{collection_id}/{document_id}/`
  
- **`app/Console/Commands/RegenerateThumbnails.php`** - Artisan command
  - Usage: `php artisan SR:RegenerateThumbnails {collection_id}` or `all`
  - Bulk regeneration with progress bar
  - Based on RebuildElasticIndex command structure

#### Modified Files
- **`app/Document.php`**
  - Added `getThumbnailUrl()` method - returns thumbnail URL or null
  - Added `hasThumbnail()` method - checks if thumbnail exists

- **`app/Http/Controllers/DocumentController.php`**
  - Integrated thumbnail generation in upload process
  - Auto-generates thumbnails for PDF uploads
  - Non-blocking (upload succeeds even if thumbnail fails)

- **`app/Traits/Search.php`**
  - Modified document list display logic
  - Shows PDF thumbnails when available
  - Falls back to default PDF icon if not present

- **`config/filesystems.php`**
  - Enabled `public` disk for thumbnail storage

- **`composer.json`**
  - Added `spatie/pdf-to-image` package (v3.1.0)

### Features
✅ **Automatic thumbnail generation** - Creates thumbnails during PDF upload  
✅ **Graceful fallback** - Uses Ghostscript + GD if Imagick unavailable  
✅ **Batch regeneration** - Command to regenerate entire collections  
✅ **Smart display** - Shows thumbnails in list view with fallback to icons  
✅ **Organized storage** - Clean directory structure per collection/document  
✅ **Non-blocking** - Upload succeeds even if thumbnail generation fails  

### Testing
- Tested with GD + Ghostscript combination
- Thumbnails generate successfully on upload
- `SR:RegenerateThumbnails` command working correctly
- List view displays thumbnails properly

### Requirements
- **PHP GD extension** (enabled) ✅
- **Ghostscript** (installed at `C:\Program Files\gs\`) ✅
- **Storage link** created (`php artisan storage:link`) ✅

### Usage
```bash
# Regenerate thumbnails for specific collection
php artisan SR:RegenerateThumbnails 2

# Regenerate thumbnails for all collections
php artisan SR:RegenerateThumbnails all
```

ScreenShot / Testing Output: 

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f534a863-4a4b-442f-8eec-b5416d699a89" />


