### PR TITLE
fix: group fixed columns, word cloud and audit trail inside Display of search results accordion panel

### DIFF
--- a/resources/views/collection-settings.blade.php
+++ b/resources/views/collection-settings.blade.php
@@ -352,24 +352,20 @@ $(document).ready(function() {
 					@if(!empty($column_config->expand_highlights_by_default)) checked="checked" @endif />
 				<label for="expand_highlights_by_default">{{ __('Expand highlights by default') }}</label>
 			</div>
-		</div>
-		<div class="form-group row align-items-center">
-			<div class="col-md-3 text-right">
-				<label for="fixed_columns_left" class="col-form-label">{{ __('Fixed columns left') }}</label>
+			<div class="form-group row align-items-center" style="width:100%;margin-top:10px;">
+				<div class="col-md-3 text-right">
+					<label for="fixed_columns_left" class="col-form-label">{{ __('Fixed columns left') }}</label>
+				</div>
+				<div class="col-md-3">
+					<input type="number" class="form-control" name="fixed_columns_left" id="fixed_columns_left" min="0" value="{{ @$column_config->fixed_columns_left ?? 0 }}" />
+				</div>
+				<div class="col-md-3 text-right">
+					<label for="fixed_columns_right" class="col-form-label">{{ __('Fixed columns right') }}</label>
+				</div>
+				<div class="col-md-3">
+					<input type="number" class="form-control" name="fixed_columns_right" id="fixed_columns_right" min="0" value="{{ @$column_config->fixed_columns_right ?? 0 }}" />
+				</div>
 			</div>
-			<div class="col-md-3">
-				<input type="number" class="form-control" name="fixed_columns_left" id="fixed_columns_left" min="0" value="{{ @$column_config->fixed_columns_left ?? 0 }}" />
-			</div>
-			<div class="col-md-3 text-right">
-				<label for="fixed_columns_right" class="col-form-label">{{ __('Fixed columns right') }}</label>
-			</div>
-			<div class="col-md-3">
-				<input type="number" class="form-control" name="fixed_columns_right" id="fixed_columns_right" min="0" value="{{ @$column_config->fixed_columns_right ?? 0 }}" />
-			</div>
-		</div>
-
-		<h4>{{ __('Info page') }}</h4>
-		<div class="form-group row">
 			<div class="col-md-12">
 				<input type="checkbox" name="show_word_cloud" id="show_word_cloud" value="1"
 					@if(!empty($column_config->show_word_cloud)) checked="checked" @endif />


### PR DESCRIPTION
Follow-up fix for #352 as requested by @ketan404.

The expand highlights checkbox, fixed columns left/right, show word cloud 
and show audit trail are now all inside the same collapsing accordion div 
under "Display of search results". The separate "Info page" section has 
been removed and merged into this single panel.
